### PR TITLE
feat(sv2): add protocol primitives

### DIFF
--- a/stratum_v2_frame.go
+++ b/stratum_v2_frame.go
@@ -1,0 +1,302 @@
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+	"sync"
+)
+
+const sv2PlaintextFramePayloadMax = 64*1024 - 6
+
+const sv2ExtensionTypeNone uint16 = 0x0000
+const sv2ExtensionTypeCompat0800 uint16 = 0x0080
+
+var sv2UnknownExtensionTypesSeen sync.Map
+
+func sv2IsSupportedExtensionType(ext uint16) bool {
+	switch ext {
+	case sv2ExtensionTypeNone, sv2ExtensionTypeCompat0800:
+		return true
+	default:
+		return false
+	}
+}
+
+func sv2ObserveExtensionType(ext uint16, transport string) {
+	if sv2IsSupportedExtensionType(ext) {
+		return
+	}
+	if _, loaded := sv2UnknownExtensionTypesSeen.LoadOrStore(ext, struct{}{}); loaded {
+		return
+	}
+	logger.Warn("sv2 frame extension type not recognized; accepting for compatibility",
+		"component", "stratum",
+		"kind", "sv2",
+		"transport", transport,
+		"extension_type", fmt.Sprintf("0x%04x", ext),
+		"todo", "verify extension semantics against sv2 extension registry",
+	)
+}
+
+// sv2ReadFrame reads a 6-byte SV2 frame header and payload.
+// Header: extension_type[u16 LE] + msg_type[u8] + payload_length[u24 LE]
+func sv2ReadFrame(r io.Reader) (msgType byte, payload []byte, err error) {
+	var hdr [6]byte
+	if _, err = io.ReadFull(r, hdr[:]); err != nil {
+		return
+	}
+	ext := binary.LittleEndian.Uint16(hdr[0:2])
+	sv2ObserveExtensionType(ext, "plaintext")
+	msgType = hdr[2]
+	payLen := uint32(hdr[3]) | uint32(hdr[4])<<8 | uint32(hdr[5])<<16
+	if payLen > sv2PlaintextFramePayloadMax {
+		return 0, nil, fmt.Errorf("sv2 frame payload too large: %d", payLen)
+	}
+	if payLen > 0 {
+		payload = make([]byte, payLen)
+		_, err = io.ReadFull(r, payload)
+	}
+	return
+}
+
+// sv2WriteFrame writes an SV2 frame with extension_type=0.
+func sv2WriteFrame(w io.Writer, msgType byte, payload []byte) error {
+	payLen := len(payload)
+	if payLen > sv2PlaintextFramePayloadMax {
+		return fmt.Errorf("sv2 frame payload too large: %d", payLen)
+	}
+	hdr := [6]byte{
+		0, 0, // extension_type = 0
+		msgType,
+		byte(payLen), byte(payLen >> 8), byte(payLen >> 16),
+	}
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	if len(payload) > 0 {
+		_, err := w.Write(payload)
+		return err
+	}
+	return nil
+}
+
+// --- Read helpers ---
+
+func sv2ReadU8(b []byte, off *int) (uint8, error) {
+	if *off+1 > len(b) {
+		return 0, io.ErrUnexpectedEOF
+	}
+	v := b[*off]
+	*off++
+	return v, nil
+}
+
+func sv2ReadU16(b []byte, off *int) (uint16, error) {
+	if *off+2 > len(b) {
+		return 0, io.ErrUnexpectedEOF
+	}
+	v := binary.LittleEndian.Uint16(b[*off:])
+	*off += 2
+	return v, nil
+}
+
+func sv2ReadU32(b []byte, off *int) (uint32, error) {
+	if *off+4 > len(b) {
+		return 0, io.ErrUnexpectedEOF
+	}
+	v := binary.LittleEndian.Uint32(b[*off:])
+	*off += 4
+	return v, nil
+}
+
+func sv2ReadU64(b []byte, off *int) (uint64, error) {
+	if *off+8 > len(b) {
+		return 0, io.ErrUnexpectedEOF
+	}
+	v := binary.LittleEndian.Uint64(b[*off:])
+	*off += 8
+	return v, nil
+}
+
+func sv2ReadU256(b []byte, off *int) ([32]byte, error) {
+	if *off+32 > len(b) {
+		return [32]byte{}, io.ErrUnexpectedEOF
+	}
+	var v [32]byte
+	copy(v[:], b[*off:*off+32])
+	*off += 32
+	return v, nil
+}
+
+func sv2ReadBool(b []byte, off *int) (bool, error) {
+	v, err := sv2ReadU8(b, off)
+	return v != 0, err
+}
+
+func sv2ReadOptU32(b []byte, off *int) (*uint32, error) {
+	present, err := sv2ReadBool(b, off)
+	if err != nil {
+		return nil, err
+	}
+	if !present {
+		return nil, nil
+	}
+	v, err := sv2ReadU32(b, off)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func sv2ReadF32(b []byte, off *int) (float32, error) {
+	bits, err := sv2ReadU32(b, off)
+	if err != nil {
+		return 0, err
+	}
+	return math.Float32frombits(bits), nil
+}
+
+func sv2ReadStr(b []byte, off *int) (string, error) {
+	length, err := sv2ReadU8(b, off)
+	if err != nil {
+		return "", err
+	}
+	if *off+int(length) > len(b) {
+		return "", io.ErrUnexpectedEOF
+	}
+	s := string(b[*off : *off+int(length)])
+	*off += int(length)
+	return s, nil
+}
+
+func sv2ReadBytes(b []byte, off *int) ([]byte, error) {
+	length, err := sv2ReadU8(b, off)
+	if err != nil {
+		return nil, err
+	}
+	if *off+int(length) > len(b) {
+		return nil, io.ErrUnexpectedEOF
+	}
+	v := make([]byte, length)
+	copy(v, b[*off:*off+int(length)])
+	*off += int(length)
+	return v, nil
+}
+
+func sv2ReadU256Seq(b []byte, off *int) ([][32]byte, error) {
+	count, err := sv2ReadU8(b, off)
+	if err != nil {
+		return nil, err
+	}
+	result := make([][32]byte, count)
+	for i := range int(count) {
+		result[i], err = sv2ReadU256(b, off)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+// sv2ReadBytesB0_64K reads bytes with a u16 LE length prefix (for cbprefix/cbsuffix in NewMiningJob).
+func sv2ReadBytesB0_64K(b []byte, off *int) ([]byte, error) {
+	if *off+2 > len(b) {
+		return nil, io.ErrUnexpectedEOF
+	}
+	length := binary.LittleEndian.Uint16(b[*off:])
+	*off += 2
+	if *off+int(length) > len(b) {
+		return nil, io.ErrUnexpectedEOF
+	}
+	v := make([]byte, length)
+	copy(v, b[*off:*off+int(length)])
+	*off += int(length)
+	return v, nil
+}
+
+// --- Append helpers ---
+
+func sv2AppendU8(b []byte, v uint8) []byte {
+	return append(b, v)
+}
+
+func sv2AppendU16(b []byte, v uint16) []byte {
+	var buf [2]byte
+	binary.LittleEndian.PutUint16(buf[:], v)
+	return append(b, buf[:]...)
+}
+
+func sv2AppendU32(b []byte, v uint32) []byte {
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], v)
+	return append(b, buf[:]...)
+}
+
+func sv2AppendU64(b []byte, v uint64) []byte {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], v)
+	return append(b, buf[:]...)
+}
+
+func sv2AppendU256(b []byte, v [32]byte) []byte {
+	return append(b, v[:]...)
+}
+
+func sv2AppendBool(b []byte, v bool) []byte {
+	if v {
+		return append(b, 1)
+	}
+	return append(b, 0)
+}
+
+func sv2AppendOptU32(b []byte, v *uint32) []byte {
+	if v == nil {
+		return sv2AppendBool(b, false)
+	}
+	b = sv2AppendBool(b, true)
+	return sv2AppendU32(b, *v)
+}
+
+func sv2AppendF32(b []byte, v float32) []byte {
+	return sv2AppendU32(b, math.Float32bits(v))
+}
+
+func sv2AppendStr(b []byte, s string) []byte {
+	if len(s) > 255 {
+		s = s[:255]
+	}
+	b = append(b, byte(len(s)))
+	return append(b, s...)
+}
+
+func sv2AppendBytes(b []byte, v []byte) []byte {
+	if len(v) > 255 {
+		v = v[:255]
+	}
+	b = append(b, byte(len(v)))
+	return append(b, v...)
+}
+
+func sv2AppendBytesB0_64K(b []byte, v []byte) []byte {
+	l := len(v)
+	if l > 65535 {
+		l = 65535
+		v = v[:l]
+	}
+	b = sv2AppendU16(b, uint16(l))
+	return append(b, v...)
+}
+
+func sv2AppendU256Seq(b []byte, vs [][32]byte) []byte {
+	count := len(vs)
+	if count > 255 {
+		count = 255
+	}
+	b = append(b, byte(count))
+	for _, v := range vs[:count] {
+		b = sv2AppendU256(b, v)
+	}
+	return b
+}

--- a/stratum_v2_frame_test.go
+++ b/stratum_v2_frame_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"bytes"
+	"bufio"
+	"io"
+	"net"
+	"time"
+	"testing"
+)
+
+func TestSV2FrameRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	if err := sv2WriteFrame(&buf, 0x1b, []byte{1, 2, 3, 4}); err != nil {
+		t.Fatal(err)
+	}
+	mt, payload, err := sv2ReadFrame(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mt != 0x1b {
+		t.Errorf("got msgType %x, want 0x1b", mt)
+	}
+	if !bytes.Equal(payload, []byte{1, 2, 3, 4}) {
+		t.Errorf("got payload %v, want [1 2 3 4]", payload)
+	}
+}
+
+func TestSV2Primitives(t *testing.T) {
+	var b []byte
+	b = sv2AppendU8(b, 0xAB)
+	b = sv2AppendU16(b, 0x1234)
+	b = sv2AppendU32(b, 0xDEADBEEF)
+	b = sv2AppendU64(b, 0xCAFEBABE01020304)
+	b = sv2AppendBool(b, true)
+	b = sv2AppendStr(b, "hello")
+	b = sv2AppendBytes(b, []byte{0xDE, 0xAD})
+
+	off := 0
+	if v, err := sv2ReadU8(b, &off); err != nil || v != 0xAB {
+		t.Errorf("U8: got %v %v", v, err)
+	}
+	if v, err := sv2ReadU16(b, &off); err != nil || v != 0x1234 {
+		t.Errorf("U16: got %v %v", v, err)
+	}
+	if v, err := sv2ReadU32(b, &off); err != nil || v != 0xDEADBEEF {
+		t.Errorf("U32: got %v %v", v, err)
+	}
+	if v, err := sv2ReadU64(b, &off); err != nil || v != 0xCAFEBABE01020304 {
+		t.Errorf("U64: got %v %v", v, err)
+	}
+	if v, err := sv2ReadBool(b, &off); err != nil || !v {
+		t.Errorf("Bool: got %v %v", v, err)
+	}
+	if v, err := sv2ReadStr(b, &off); err != nil || v != "hello" {
+		t.Errorf("Str: got %v %v", v, err)
+	}
+	if v, err := sv2ReadBytes(b, &off); err != nil || !bytes.Equal(v, []byte{0xDE, 0xAD}) {
+		t.Errorf("Bytes: got %v %v", v, err)
+	}
+}
+
+func TestSV2ErrUnexpectedEOF(t *testing.T) {
+	b := []byte{0x01} // Only 1 byte, need 2 for U16
+	off := 0
+	_, err := sv2ReadU16(b, &off)
+	if err != io.ErrUnexpectedEOF {
+		t.Errorf("expected ErrUnexpectedEOF, got %v", err)
+	}
+}
+
+func TestSV2FrameAcceptsUnknownExtensionType(t *testing.T) {
+	var buf bytes.Buffer
+	buf.Write([]byte{0x01, 0x00, 0x1b, 0x02, 0x00, 0x00, 0xde, 0xad})
+	mt, payload, err := sv2ReadFrame(&buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mt != 0x1b {
+		t.Fatalf("got msgType %x, want 0x1b", mt)
+	}
+	if !bytes.Equal(payload, []byte{0xde, 0xad}) {
+		t.Fatalf("got payload %x", payload)
+	}
+}
+
+func TestSV2FrameAcceptsCompatExtensionType(t *testing.T) {
+	var buf bytes.Buffer
+	buf.Write([]byte{0x80, 0x00, 0x1b, 0x02, 0x00, 0x00, 0xaa, 0xbb})
+	mt, payload, err := sv2ReadFrame(&buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mt != 0x1b {
+		t.Fatalf("got msgType %x, want 0x1b", mt)
+	}
+	if !bytes.Equal(payload, []byte{0xaa, 0xbb}) {
+		t.Fatalf("got payload %x", payload)
+	}
+}
+
+func TestSV2FrameRejectsOversizePayload(t *testing.T) {
+	var buf bytes.Buffer
+	if err := sv2WriteFrame(&buf, 0x1b, bytes.Repeat([]byte{0x42}, sv2PlaintextFramePayloadMax+1)); err == nil {
+		t.Fatal("expected oversize payload error")
+	}
+
+	overSize := uint32(sv2PlaintextFramePayloadMax + 1)
+	hdr := [6]byte{0x00, 0x00, 0x1b, byte(overSize), byte(overSize >> 8), byte(overSize >> 16)}
+	if _, _, err := sv2ReadFrame(bytes.NewReader(hdr[:])); err == nil {
+		t.Fatal("expected oversize payload rejection")
+	}
+}
+
+func TestSV2MessageRoundTrips(t *testing.T) {
+	// SetupConnection
+	sc := sv2SetupConnection{
+		Protocol: 0, MinVersion: 2, MaxVersion: 2,
+		Flags: 0, EndpointHost: "127.0.0.1", EndpointPort: 3333,
+		Vendor: "test", HardwareVersion: "v1", Firmware: "fw1", DeviceID: "dev1",
+	}
+	encoded := sc.encode()
+	var sc2 sv2SetupConnection
+	if err := sc2.decode(encoded); err != nil {
+		t.Fatal(err)
+	}
+	if sc2.Protocol != sc.Protocol || sc2.EndpointHost != sc.EndpointHost {
+		t.Errorf("SetupConnection round-trip failed")
+	}
+
+	// SubmitSharesStandard
+	ss := sv2SubmitSharesStandard{
+		ChannelID: 1, SequenceNumber: 42, JobID: 7,
+		Nonce: 0xABCD1234, NTime: 0x12345678, Version: 0x20000000,
+	}
+	enc := ss.encode()
+	var ss2 sv2SubmitSharesStandard
+	if err := ss2.decode(enc); err != nil {
+		t.Fatal(err)
+	}
+	if ss2.Nonce != ss.Nonce || ss2.Version != ss.Version {
+		t.Errorf("SubmitSharesStandard round-trip failed: %+v vs %+v", ss, ss2)
+	}
+}
+
+func TestSV2ProtocolDetector(t *testing.T) {
+	tests := []struct {
+		name     string
+		probe    []byte
+		wantKind sv2ProtocolKind
+	}{
+		{name: "json", probe: []byte("  {\"id\":1}"), wantKind: sv2ProtocolSV1JSON},
+		{name: "plaintext", probe: []byte{0x00, 0x00, sv2MsgSetupConnection, 0x00, 0x00, 0x00}, wantKind: sv2ProtocolPlaintext},
+		{name: "encrypted fallback", probe: []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}, wantKind: sv2ProtocolEncrypted},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server, client := net.Pipe()
+			defer server.Close()
+			defer client.Close()
+
+			go func() {
+				_, _ = client.Write(tc.probe)
+		}()
+
+			kind, err := detectStratumProtocol(server, bufio.NewReaderSize(server, maxStratumMessageSize), Config{ConnectionTimeout: time.Second})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if kind != tc.wantKind {
+				t.Fatalf("got kind %v, want %v", kind, tc.wantKind)
+			}
+		})
+	}
+}

--- a/stratum_v2_key.go
+++ b/stratum_v2_key.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"encoding/base64"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/base58"
+)
+
+type sv2KeyPair struct {
+	privKey *btcec.PrivateKey
+	pubKey  *btcec.PublicKey
+}
+
+type sv2StaticKey struct {
+	sv2KeyPair
+}
+
+type sv2AuthorityKey struct {
+	sv2KeyPair
+}
+
+func loadOrGenerateSV2Key(path string) (*sv2StaticKey, error) {
+	pair, err := loadOrGenerateSV2KeyPair(path)
+	if err != nil {
+		return nil, err
+	}
+	return &sv2StaticKey{sv2KeyPair: *pair}, nil
+}
+
+func loadOrGenerateSV2AuthorityKey(path string) (*sv2AuthorityKey, error) {
+	pair, err := loadOrGenerateSV2KeyPair(path)
+	if err != nil {
+		return nil, err
+	}
+	return &sv2AuthorityKey{sv2KeyPair: *pair}, nil
+}
+
+func loadSV2KeyFromBase64(encoded string) (*sv2StaticKey, error) {
+	pair, err := loadSV2KeyPairFromBase64(encoded)
+	if err != nil {
+		return nil, err
+	}
+	return &sv2StaticKey{sv2KeyPair: *pair}, nil
+}
+
+func loadSV2AuthorityKeyFromBase64(encoded string) (*sv2AuthorityKey, error) {
+	pair, err := loadSV2KeyPairFromBase64(encoded)
+	if err != nil {
+		return nil, err
+	}
+	return &sv2AuthorityKey{sv2KeyPair: *pair}, nil
+}
+
+func loadSV2KeyPairFromBase64(encoded string) (*sv2KeyPair, error) {
+	raw := strings.TrimSpace(encoded)
+	if raw == "" {
+		return nil, fmt.Errorf("sv2 key base64 is empty")
+	}
+	data, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("sv2 key base64 decode: %w", err)
+	}
+	if len(data) != 32 {
+		return nil, fmt.Errorf("sv2 key base64 decoded length %d, want 32", len(data))
+	}
+	privKey, pubKey := btcec.PrivKeyFromBytes(data)
+	return &sv2KeyPair{privKey: privKey, pubKey: pubKey}, nil
+}
+
+func loadOrGenerateSV2KeyPair(path string) (*sv2KeyPair, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return nil, fmt.Errorf("sv2 key dir: %w", err)
+	}
+	data, err := os.ReadFile(path)
+	if err == nil && len(data) == 32 {
+		privKey, pubKey := btcec.PrivKeyFromBytes(data)
+		return &sv2KeyPair{privKey: privKey, pubKey: pubKey}, nil
+	}
+	// Generate new key
+	privKey, err := btcec.NewPrivateKey()
+	if err != nil {
+		return nil, fmt.Errorf("sv2 key gen: %w", err)
+	}
+	keyBytes := privKey.Serialize() // 32-byte big-endian scalar
+	if err := os.WriteFile(path, keyBytes, 0600); err != nil {
+		return nil, fmt.Errorf("sv2 key save: %w", err)
+	}
+	return &sv2KeyPair{privKey: privKey, pubKey: privKey.PubKey()}, nil
+}
+
+func (k *sv2StaticKey) pubHex() string {
+	if k == nil || k.pubKey == nil {
+		return ""
+	}
+	return hex.EncodeToString(k.pubKey.SerializeCompressed())
+}
+
+func (k *sv2AuthorityKey) pubHex() string {
+	if k == nil || k.pubKey == nil {
+		return ""
+	}
+	return hex.EncodeToString(k.pubKey.SerializeCompressed())
+}
+
+func sv2AuthorityKeyFromStaticKey(staticKey *sv2StaticKey) *sv2AuthorityKey {
+	if staticKey == nil {
+		return nil
+	}
+	return &sv2AuthorityKey{sv2KeyPair: staticKey.sv2KeyPair}
+}
+
+// sv2AuthorityKeyBase58Check encodes a 32-byte x-only secp256k1 public key in
+// the SV2 URL format used for the Pool Authority Key.
+func sv2AuthorityKeyBase58Check(pubKey *btcec.PublicKey) string {
+	if pubKey == nil {
+		return ""
+	}
+	xBytes := pubKey.X().Bytes()
+	xOnly := make([]byte, 32)
+	copy(xOnly[32-len(xBytes):], xBytes)
+	payload := make([]byte, 34)
+	payload[0] = 0x01
+	payload[1] = 0x00
+	copy(payload[2:], xOnly)
+	h1 := sha256.Sum256(payload)
+	h2 := sha256.Sum256(h1[:])
+	return base58.Encode(append(payload, h2[:4]...))
+}
+
+func (k *sv2AuthorityKey) authKeyBase58Check() string {
+	return sv2AuthorityKeyBase58Check(k.pubKey)
+}

--- a/stratum_v2_key_more_test.go
+++ b/stratum_v2_key_more_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/base58"
+)
+
+func TestLoadSV2KeyPairFromBase64RejectsEmptyAndInvalid(t *testing.T) {
+	if _, err := loadSV2KeyPairFromBase64("   \n\t "); err == nil {
+		t.Fatalf("expected empty input error")
+	}
+	if _, err := loadSV2KeyPairFromBase64("not_base64"); err == nil {
+		t.Fatalf("expected decode error")
+	}
+}
+
+func TestLoadSV2KeyWrappersFromBase64(t *testing.T) {
+	raw := make([]byte, 32)
+	raw[0] = 1
+	raw[31] = 2
+	enc := base64.StdEncoding.EncodeToString(raw)
+
+	staticKey, err := loadSV2KeyFromBase64(enc)
+	if err != nil {
+		t.Fatalf("loadSV2KeyFromBase64: %v", err)
+	}
+	authKey, err := loadSV2AuthorityKeyFromBase64(enc)
+	if err != nil {
+		t.Fatalf("loadSV2AuthorityKeyFromBase64: %v", err)
+	}
+	if staticKey == nil || staticKey.privKey == nil || staticKey.pubKey == nil {
+		t.Fatalf("static key is not populated")
+	}
+	if authKey == nil || authKey.privKey == nil || authKey.pubKey == nil {
+		t.Fatalf("authority key is not populated")
+	}
+}
+
+func TestLoadOrGenerateSV2KeyPairRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "sv2", "key.bin")
+
+	first, err := loadOrGenerateSV2KeyPair(path)
+	if err != nil {
+		t.Fatalf("first load/generate: %v", err)
+	}
+	if first == nil || first.privKey == nil || first.pubKey == nil {
+		t.Fatalf("first key pair not populated")
+	}
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat key file: %v", err)
+	}
+	if st.Mode().Perm() != 0600 {
+		t.Fatalf("unexpected key file mode: got %o want 600", st.Mode().Perm())
+	}
+
+	second, err := loadOrGenerateSV2KeyPair(path)
+	if err != nil {
+		t.Fatalf("second load/generate: %v", err)
+	}
+	if second == nil || second.privKey == nil || second.pubKey == nil {
+		t.Fatalf("second key pair not populated")
+	}
+	if !bytes.Equal(second.privKey.Serialize(), first.privKey.Serialize()) {
+		t.Fatalf("expected persisted key to reload without regeneration")
+	}
+}
+
+func TestLoadOrGenerateSV2KeyPairRegeneratesOnWrongLength(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "key.bin")
+	if err := os.WriteFile(path, []byte{0x01, 0x02}, 0600); err != nil {
+		t.Fatalf("write short key: %v", err)
+	}
+	pair, err := loadOrGenerateSV2KeyPair(path)
+	if err != nil {
+		t.Fatalf("load/generate: %v", err)
+	}
+	if pair == nil || pair.privKey == nil || pair.pubKey == nil {
+		t.Fatalf("regenerated key pair not populated")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read key file: %v", err)
+	}
+	if len(raw) != 32 {
+		t.Fatalf("expected regenerated key length 32, got %d", len(raw))
+	}
+}
+
+func TestSV2KeyPublicHelpers(t *testing.T) {
+	if (*sv2StaticKey)(nil).pubHex() != "" {
+		t.Fatalf("nil static key pubHex must be empty")
+	}
+	if (*sv2AuthorityKey)(nil).pubHex() != "" {
+		t.Fatalf("nil authority key pubHex must be empty")
+	}
+	if sv2AuthorityKeyFromStaticKey(nil) != nil {
+		t.Fatalf("nil static key should produce nil authority key")
+	}
+
+	raw := make([]byte, 32)
+	raw[31] = 3
+	priv, pub := btcec.PrivKeyFromBytes(raw)
+	staticKey := &sv2StaticKey{sv2KeyPair: sv2KeyPair{privKey: priv, pubKey: pub}}
+	authority := sv2AuthorityKeyFromStaticKey(staticKey)
+	if authority == nil || authority.pubKey == nil {
+		t.Fatalf("expected authority key from static key")
+	}
+	if authority.pubHex() == "" {
+		t.Fatalf("expected non-empty authority public hex")
+	}
+}
+
+func TestSV2AuthorityKeyBase58CheckHelpers(t *testing.T) {
+	if sv2AuthorityKeyBase58Check(nil) != "" {
+		t.Fatalf("nil pubkey should encode as empty string")
+	}
+	if (&sv2AuthorityKey{}).authKeyBase58Check() != "" {
+		t.Fatalf("nil authority pubkey should encode as empty string")
+	}
+
+	raw := make([]byte, 32)
+	raw[30] = 0x11
+	raw[31] = 0x22
+	_, pub := btcec.PrivKeyFromBytes(raw)
+	encoded := sv2AuthorityKeyBase58Check(pub)
+	if strings.TrimSpace(encoded) == "" {
+		t.Fatalf("expected non-empty base58check encoding")
+	}
+	decoded := base58.Decode(encoded)
+	if len(decoded) != 38 {
+		t.Fatalf("unexpected decoded length: got %d want 38", len(decoded))
+	}
+	if decoded[0] != 0x01 || decoded[1] != 0x00 {
+		t.Fatalf("unexpected prefix bytes: %x %x", decoded[0], decoded[1])
+	}
+	payload := decoded[:34]
+	checksum := decoded[34:]
+	h1 := sha256.Sum256(payload)
+	h2 := sha256.Sum256(h1[:])
+	if !strings.EqualFold(base64.StdEncoding.EncodeToString(checksum), base64.StdEncoding.EncodeToString(h2[:4])) {
+		t.Fatalf("invalid checksum in base58check encoding")
+	}
+}

--- a/stratum_v2_key_test.go
+++ b/stratum_v2_key_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcutil/base58"
+)
+
+// TestSV2AuthKeyTestVector verifies the authority-key base58check encoding
+// against the SV2 spec §4.7 test vector.
+func TestSV2AuthKeyTestVector(t *testing.T) {
+	// raw_ca_public_key from the spec (32 bytes)
+	rawKey := []byte{118, 99, 112, 0, 151, 156, 28, 17, 175, 12, 48, 11, 205, 140, 127, 228, 134, 16, 252, 233, 185, 193, 30, 61, 174, 227, 90, 224, 176, 138, 116, 85}
+	expected := "9bXiEd8boQVhq7WddEcERUL5tyyJVFYdU8th3HfbNXK3Yw6GRXh"
+
+	payload := make([]byte, 34)
+	payload[0] = 0x01
+	payload[1] = 0x00
+	copy(payload[2:], rawKey)
+	h1 := sha256.Sum256(payload)
+	h2 := sha256.Sum256(h1[:])
+	full := append(payload, h2[:4]...)
+	result := base58.Encode(full)
+
+	if result != expected {
+		t.Errorf("expected %s, got %s", expected, result)
+	}
+}

--- a/stratum_v2_noise.go
+++ b/stratum_v2_noise.go
@@ -1,0 +1,378 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ellswift"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"golang.org/x/crypto/chacha20poly1305"
+	"golang.org/x/crypto/hkdf"
+)
+
+const sv2NoiseProtocolNameEllSwift = "Noise_NX_Secp256k1+EllSwift_ChaChaPoly_SHA256"
+
+type noiseState struct {
+	ck     [32]byte
+	h      [32]byte
+	k      [32]byte
+	n      uint64
+	hasKey bool
+}
+
+func noiseInitializeSymmetric(protocolName string) noiseState {
+	var s noiseState
+	nameBytes := []byte(protocolName)
+	if len(nameBytes) <= 32 {
+		copy(s.ck[:], nameBytes)
+	} else {
+		s.ck = sha256.Sum256(nameBytes)
+	}
+	s.h = s.ck
+	return s
+}
+
+func (s *noiseState) mixHash(data []byte) {
+	h := sha256.New()
+	h.Write(s.h[:])
+	h.Write(data)
+	copy(s.h[:], h.Sum(nil))
+}
+
+func noiseHKDF(ck [32]byte, ikm []byte) (ck2 [32]byte, k [32]byte) {
+	r := hkdf.New(sha256.New, ikm, ck[:], nil)
+	var out [64]byte
+	if _, err := io.ReadFull(r, out[:]); err != nil {
+		panic(fmt.Sprintf("sv2 hkdf: %v", err))
+	}
+	copy(ck2[:], out[:32])
+	copy(k[:], out[32:])
+	return
+}
+
+func (s *noiseState) mixKey(ikm []byte) {
+	s.ck, s.k = noiseHKDF(s.ck, ikm)
+	s.n = 0
+	s.hasKey = true
+}
+
+func noiseNonce(n uint64) [12]byte {
+	var nonce [12]byte
+	binary.LittleEndian.PutUint64(nonce[4:], n)
+	return nonce
+}
+
+func (s *noiseState) encryptAndHash(plaintext []byte) ([]byte, error) {
+	if !s.hasKey {
+		s.mixHash(plaintext)
+		return plaintext, nil
+	}
+	aead, err := chacha20poly1305.New(s.k[:])
+	if err != nil {
+		return nil, err
+	}
+	nonce := noiseNonce(s.n)
+	ciphertext := aead.Seal(nil, nonce[:], plaintext, s.h[:])
+	s.mixHash(ciphertext)
+	s.n++
+	return ciphertext, nil
+}
+
+func (s *noiseState) decryptAndHash(ciphertext []byte) ([]byte, error) {
+	if !s.hasKey {
+		s.mixHash(ciphertext)
+		return ciphertext, nil
+	}
+	aead, err := chacha20poly1305.New(s.k[:])
+	if err != nil {
+		return nil, err
+	}
+	nonce := noiseNonce(s.n)
+	plaintext, err := aead.Open(nil, nonce[:], ciphertext, s.h[:])
+	if err != nil {
+		return nil, fmt.Errorf("noise decrypt: %w", err)
+	}
+	s.mixHash(ciphertext)
+	s.n++
+	return plaintext, nil
+}
+
+func (s *noiseState) split() (k1, k2 [32]byte) {
+	k1, k2 = noiseHKDF(s.ck, nil)
+	return
+}
+
+func noiseECDH(priv *btcec.PrivateKey, pub *btcec.PublicKey) []byte {
+	return btcec.GenerateSharedSecret(priv, pub)
+}
+
+func sv2NoiseLogHexPrefix(step string, b []byte, n int) {
+	if !logger.Enabled(logLevelDebug) {
+		return
+	}
+	if n > len(b) {
+		n = len(b)
+	}
+	logger.Debug("sv2 noise",
+		"component", "stratum",
+		"kind", "sv2_noise",
+		"step", step,
+		"hex", fmt.Sprintf("%x", b[:n]),
+	)
+}
+
+// sv2NoiseHandshake performs the responder-side NX EllSwift handshake and returns an encrypted transport conn.
+//
+// TODO: this path is intentionally experimental until initiator-side authority
+// certificate verification is implemented and exercised against official test
+// vectors.
+func sv2NoiseHandshake(conn net.Conn, staticKey *sv2StaticKey, authorityKey *sv2AuthorityKey) (net.Conn, error) {
+	var eEll [64]byte
+	if _, err := io.ReadFull(conn, eEll[:]); err != nil {
+		return nil, fmt.Errorf("sv2 noise: read ellswift ephemeral pubkey: %w", err)
+	}
+	return sv2NoiseHandshakeEllSwift(conn, staticKey, authorityKey, eEll)
+}
+
+func sv2NoiseHandshakeEllSwift(conn net.Conn, staticKey *sv2StaticKey, authorityKey *sv2AuthorityKey, eEll [64]byte) (net.Conn, error) {
+	s := noiseInitializeSymmetric(sv2NoiseProtocolNameEllSwift)
+	// Empty prologue
+	s.mixHash([]byte{})
+	sv2NoiseLogHexPrefix("h_after_prologue", s.h[:], 32)
+	sv2NoiseLogHexPrefix("e_pub", eEll[:], 16)
+	s.mixHash(eEll[:])
+	// Extra empty-payload mixHash after 'e' token, matching the SV2 initiator behavior.
+	s.mixHash([]byte{})
+
+	// Step 2: Generate responder ephemeral key as EllSwift and send it.
+	re, reEll, err := ellswift.EllswiftCreate()
+	if err != nil {
+		return nil, fmt.Errorf("sv2 noise ellswift: gen ephemeral key: %w", err)
+	}
+	if _, err := conn.Write(reEll[:]); err != nil {
+		return nil, fmt.Errorf("sv2 noise ellswift: send ephemeral pubkey: %w", err)
+	}
+	sv2NoiseLogHexPrefix("re_pub", reEll[:], 16)
+	s.mixHash(reEll[:])
+
+	// Step 3: ee using BIP324 x-only hash over EllSwift keys.
+	ee, err := ellswift.V2Ecdh(re, eEll, reEll, false)
+	if err != nil {
+		return nil, fmt.Errorf("sv2 noise ellswift: ee ecdh: %w", err)
+	}
+	sv2NoiseLogHexPrefix("ecdh_shared", ee[:], 16)
+	sv2NoiseLogHexPrefix("ck_before_hkdf", s.ck[:], 32)
+	s.mixKey(ee[:])
+	sv2NoiseLogHexPrefix("h_aad_for_encrypt_static", s.h[:], 32)
+	sv2NoiseLogHexPrefix("ck_after_hkdf", s.ck[:], 32)
+	sv2NoiseLogHexPrefix("temp_k_encrypt_static", s.k[:], 32)
+
+	// Step 4: Encrypt and send responder static pubkey encoded as EllSwift (64 bytes).
+	rsStaticEll, xOnly, err := sv2EncodeStaticEllSwift(staticKey)
+	if err != nil {
+		return nil, fmt.Errorf("sv2 noise ellswift: encode static pubkey: %w", err)
+	}
+	encStatic, err := s.encryptAndHash(rsStaticEll[:])
+	if err != nil {
+		return nil, fmt.Errorf("sv2 noise ellswift: encrypt static: %w", err)
+	}
+	sv2NoiseLogHexPrefix("enc_static_first32", encStatic, 32)
+	if len(encStatic) >= chacha20poly1305.Overhead {
+		sv2NoiseLogHexPrefix("enc_static_mac", encStatic[len(encStatic)-chacha20poly1305.Overhead:], chacha20poly1305.Overhead)
+	}
+	if _, err := conn.Write(encStatic); err != nil {
+		return nil, fmt.Errorf("sv2 noise ellswift: send static: %w", err)
+	}
+
+	// Step 5: es using BIP324 x-only hash over initiator ephemeral and responder static EllSwift.
+	es, err := ellswift.V2Ecdh(staticKey.privKey, eEll, rsStaticEll, false)
+	if err != nil {
+		return nil, fmt.Errorf("sv2 noise ellswift: es ecdh: %w", err)
+	}
+	s.mixKey(es[:])
+
+	// Step 6: Encrypt and send server certificate payload (74 bytes plaintext, 90 bytes ciphertext).
+	if authorityKey == nil {
+		authorityKey = sv2AuthorityKeyFromStaticKey(staticKey)
+	}
+	certPayload, err := sv2BuildServerCertPayload(authorityKey, xOnly)
+	if err != nil {
+		return nil, fmt.Errorf("sv2 noise ellswift: build cert payload: %w", err)
+	}
+	encCert, err := s.encryptAndHash(certPayload[:])
+	if err != nil {
+		return nil, fmt.Errorf("sv2 noise ellswift: encrypt cert payload: %w", err)
+	}
+	if _, err := conn.Write(encCert); err != nil {
+		return nil, fmt.Errorf("sv2 noise ellswift: send cert payload: %w", err)
+	}
+
+	// Step 7: Split into transport keys.
+	k1, k2 := s.split()
+
+	return &sv2EncryptedFrameConn{
+		Conn:    conn,
+		sendKey: k2,
+		recvKey: k1,
+	}, nil
+}
+
+// sv2EncryptedFrameConn implements SV2 frame-oriented encrypted transport used
+// by the EllSwift client path (encrypted header then encrypted payload).
+type sv2EncryptedFrameConn struct {
+	net.Conn
+	sendKey [32]byte
+	recvKey [32]byte
+	sendN   uint64
+	recvN   uint64
+	sendMu  sync.Mutex
+	recvMu  sync.Mutex
+}
+
+func sv2EncodeStaticEllSwift(staticKey *sv2StaticKey) ([64]byte, [32]byte, error) {
+	var out [64]byte
+	var xOnly [32]byte
+
+	comp := staticKey.pubKey.SerializeCompressed()
+	copy(xOnly[:], comp[1:33])
+
+	var x btcec.FieldVal
+	overflow := x.SetByteSlice(xOnly[:])
+	if overflow {
+		x.Normalize()
+	}
+	u, t, err := ellswift.XElligatorSwift(&x)
+	if err != nil {
+		return out, xOnly, err
+	}
+	uBytes := u.Bytes()
+	tBytes := t.Bytes()
+	copy(out[0:32], (*uBytes)[:])
+	copy(out[32:64], (*tBytes)[:])
+	return out, xOnly, nil
+}
+
+func sv2BuildServerCertPayload(authorityKey *sv2AuthorityKey, staticXOnly [32]byte) ([74]byte, error) {
+	var payload [74]byte
+	binary.LittleEndian.PutUint16(payload[0:2], 0x0001)
+	now := time.Now().UTC()
+	validFrom := uint32(now.Unix())
+	validTo := uint32(now.Add(365 * 24 * time.Hour).Unix())
+	binary.LittleEndian.PutUint32(payload[2:6], validFrom)
+	binary.LittleEndian.PutUint32(payload[6:10], validTo)
+
+	h := sha256.New()
+	h.Write(payload[:10])
+	h.Write(staticXOnly[:])
+	sigHash := h.Sum(nil)
+	if authorityKey == nil || authorityKey.privKey == nil {
+		return payload, fmt.Errorf("sv2 certificate authority key is not configured")
+	}
+	sig, err := schnorr.Sign(authorityKey.privKey, sigHash)
+	if err != nil {
+		return payload, err
+	}
+	copy(payload[10:], sig.Serialize())
+	return payload, nil
+}
+
+func (c *sv2EncryptedFrameConn) Write(p []byte) (int, error) {
+	return 0, fmt.Errorf("sv2 frame conn: raw Write unsupported")
+}
+
+func (c *sv2EncryptedFrameConn) Read(p []byte) (int, error) {
+	return 0, fmt.Errorf("sv2 frame conn: raw Read unsupported")
+}
+
+func (c *sv2EncryptedFrameConn) WriteSV2Frame(msgType byte, payload []byte) error {
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
+	if len(payload) > sv2PlaintextFramePayloadMax-16 {
+		return fmt.Errorf("sv2 frame payload too large: %d", len(payload))
+	}
+
+	header := [6]byte{0, 0, msgType, byte(len(payload)), byte(len(payload) >> 8), byte(len(payload) >> 16)}
+	encHeader, err := sv2EncryptWithKey(c.sendKey, c.sendN, header[:])
+	if err != nil {
+		return err
+	}
+	c.sendN++
+	if _, err := c.Conn.Write(encHeader); err != nil {
+		return err
+	}
+
+	if len(payload) == 0 {
+		return nil
+	}
+	encPayload, err := sv2EncryptWithKey(c.sendKey, c.sendN, payload)
+	if err != nil {
+		return err
+	}
+	c.sendN++
+	_, err = c.Conn.Write(encPayload)
+	return err
+}
+
+func (c *sv2EncryptedFrameConn) ReadSV2Frame() (byte, []byte, error) {
+	c.recvMu.Lock()
+	defer c.recvMu.Unlock()
+
+	encHeader := make([]byte, 22)
+	if _, err := io.ReadFull(c.Conn, encHeader); err != nil {
+		return 0, nil, err
+	}
+	header, err := sv2DecryptWithKey(c.recvKey, c.recvN, encHeader)
+	if err != nil {
+		return 0, nil, fmt.Errorf("sv2 frame decrypt header: %w", err)
+	}
+	c.recvN++
+	if len(header) != 6 {
+		return 0, nil, fmt.Errorf("sv2 frame header len %d", len(header))
+	}
+	ext := binary.LittleEndian.Uint16(header[0:2])
+	sv2ObserveExtensionType(ext, "encrypted")
+
+	msgType := header[2]
+	payLen := uint32(header[3]) | uint32(header[4])<<8 | uint32(header[5])<<16
+	if payLen == 0 {
+		return msgType, nil, nil
+	}
+	if payLen > sv2PlaintextFramePayloadMax-16 {
+		return 0, nil, fmt.Errorf("sv2 frame payload too large: %d", payLen)
+	}
+
+	encPayload := make([]byte, int(payLen)+chacha20poly1305.Overhead)
+	if _, err := io.ReadFull(c.Conn, encPayload); err != nil {
+		return 0, nil, err
+	}
+	payload, err := sv2DecryptWithKey(c.recvKey, c.recvN, encPayload)
+	if err != nil {
+		return 0, nil, fmt.Errorf("sv2 frame decrypt payload: %w", err)
+	}
+	c.recvN++
+	return msgType, payload, nil
+}
+
+func sv2EncryptWithKey(key [32]byte, n uint64, plaintext []byte) ([]byte, error) {
+	aead, err := chacha20poly1305.New(key[:])
+	if err != nil {
+		return nil, err
+	}
+	nonce := noiseNonce(n)
+	return aead.Seal(nil, nonce[:], plaintext, nil), nil
+}
+
+func sv2DecryptWithKey(key [32]byte, n uint64, ciphertext []byte) ([]byte, error) {
+	aead, err := chacha20poly1305.New(key[:])
+	if err != nil {
+		return nil, err
+	}
+	nonce := noiseNonce(n)
+	return aead.Open(nil, nonce[:], ciphertext, nil)
+}

--- a/stratum_v2_noise_test.go
+++ b/stratum_v2_noise_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/ellswift"
+	"golang.org/x/crypto/chacha20poly1305"
+)
+// testNoiseInitiator implements the NX initiator side for testing.
+func testNoiseInitiator(conn net.Conn) (net.Conn, error) {
+	s := noiseInitializeSymmetric(sv2NoiseProtocolNameEllSwift)
+	s.mixHash([]byte{})
+
+	// Generate EllSwift initiator ephemeral key.
+	ePriv, ePubEll, err := ellswift.EllswiftCreate()
+	if err != nil {
+		return nil, err
+	}
+	s.mixHash(ePubEll[:])
+	// Extra empty-payload mixHash after 'e' token (matches server/SV2 spec).
+	s.mixHash([]byte{})
+
+	if _, err := conn.Write(ePubEll[:]); err != nil {
+		return nil, err
+	}
+
+	var rePubEll [64]byte
+	if _, err := io.ReadFull(conn, rePubEll[:]); err != nil {
+		return nil, err
+	}
+	s.mixHash(rePubEll[:])
+
+	ee, err := ellswift.V2Ecdh(ePriv, rePubEll, ePubEll, true)
+	if err != nil {
+		return nil, err
+	}
+	s.mixKey(ee[:])
+
+	// Read encrypted static (80 bytes = 64 + tag).
+	encStatic := make([]byte, 64+chacha20poly1305.Overhead)
+	if _, err := io.ReadFull(conn, encStatic); err != nil {
+		return nil, err
+	}
+	rsStaticEll, err := s.decryptAndHash(encStatic)
+	if err != nil {
+		return nil, err
+	}
+	if len(rsStaticEll) != 64 {
+		return nil, io.ErrUnexpectedEOF
+	}
+	var rsStatic [64]byte
+	copy(rsStatic[:], rsStaticEll)
+
+	es, err := ellswift.V2Ecdh(ePriv, rsStatic, ePubEll, true)
+	if err != nil {
+		return nil, err
+	}
+	s.mixKey(es[:])
+
+	// Read encrypted certificate payload (90 bytes = 74 + tag).
+	encCert := make([]byte, 74+chacha20poly1305.Overhead)
+	if _, err := io.ReadFull(conn, encCert); err != nil {
+		return nil, err
+	}
+	certPayload, err := s.decryptAndHash(encCert)
+	if err != nil {
+		return nil, err
+	}
+	if len(certPayload) != 74 {
+		return nil, io.ErrUnexpectedEOF
+	}
+	_ = binary.LittleEndian.Uint16(certPayload[0:2])
+
+	k1, k2 := s.split()
+	return &sv2EncryptedFrameConn{
+		Conn:    conn,
+		sendKey: k1,
+		recvKey: k2,
+	}, nil
+}
+
+func TestSV2NoiseHandshakeEllSwift(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+
+	privKey, err := btcec.NewPrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	staticKey := &sv2StaticKey{sv2KeyPair: sv2KeyPair{privKey: privKey, pubKey: privKey.PubKey()}}
+
+	errCh := make(chan error, 2)
+	type result struct {
+		conn net.Conn
+		err  error
+	}
+	serverCh := make(chan result, 1)
+	clientCh := make(chan result, 1)
+
+	go func() {
+		authorityKey := sv2AuthorityKeyFromStaticKey(staticKey)
+		conn, err := sv2NoiseHandshake(serverConn, staticKey, authorityKey)
+		serverCh <- result{conn, err}
+	}()
+	go func() {
+		conn, err := testNoiseInitiator(clientConn)
+		clientCh <- result{conn, err}
+	}()
+
+	sr := <-serverCh
+	cr := <-clientCh
+	if sr.err != nil {
+		t.Fatal("server handshake error:", sr.err)
+	}
+	if cr.err != nil {
+		t.Fatal("client handshake error:", cr.err)
+	}
+
+	serverEnc, ok := sr.conn.(interface{ WriteSV2Frame(msgType byte, payload []byte) error })
+	if !ok {
+		t.Fatal("server transport does not implement frame writer")
+	}
+	clientEnc, ok := cr.conn.(interface{ ReadSV2Frame() (byte, []byte, error) })
+	if !ok {
+		t.Fatal("client transport does not implement frame reader")
+	}
+
+	// Test encrypted communication: server frame -> client frame.
+	msgType := byte(0x42)
+	msgPayload := []byte("hello sv2 ellswift")
+	go func() {
+		errCh <- serverEnc.WriteSV2Frame(msgType, msgPayload)
+	}()
+	go func() {
+		mt, payload, err := clientEnc.ReadSV2Frame()
+		if err == nil && (mt != msgType || string(payload) != string(msgPayload)) {
+			err = io.ErrUnexpectedEOF
+		}
+		errCh <- err
+	}()
+
+	for i := 0; i < 2; i++ {
+		if err := <-errCh; err != nil {
+			t.Fatal("transport error:", err)
+		}
+	}
+}

--- a/stratum_v2_protocol.go
+++ b/stratum_v2_protocol.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"time"
+)
+
+type sv2ProtocolKind int
+
+const (
+	sv2ProtocolUnknown sv2ProtocolKind = iota
+	sv2ProtocolSV1JSON
+	sv2ProtocolPlaintext
+	sv2ProtocolEncrypted
+)
+
+func detectStratumProtocol(conn net.Conn, reader *bufio.Reader, cfg Config) (sv2ProtocolKind, error) {
+	if conn == nil || reader == nil {
+		return sv2ProtocolUnknown, fmt.Errorf("sv2 protocol detection requires a live connection")
+	}
+	deadline := 5 * time.Second
+	if cfg.ConnectionTimeout > 0 && cfg.ConnectionTimeout < deadline {
+		deadline = cfg.ConnectionTimeout
+	}
+	if deadline > 0 {
+		_ = conn.SetReadDeadline(time.Now().Add(deadline))
+		defer func() {
+			_ = conn.SetReadDeadline(time.Time{})
+		}()
+	}
+	probe, err := reader.Peek(6)
+	if err != nil && !errors.Is(err, bufio.ErrBufferFull) && !errors.Is(err, io.EOF) {
+		return sv2ProtocolUnknown, err
+	}
+	if looksLikeJSONRPCStart(probe) {
+		return sv2ProtocolSV1JSON, nil
+	}
+	if len(probe) >= 3 && probe[0] == 0x00 && probe[1] == 0x00 && probe[2] == sv2MsgSetupConnection {
+		if len(probe) == 6 {
+			payLen := int(probe[3]) | int(probe[4])<<8 | int(probe[5])<<16
+			if payLen > sv2PlaintextFramePayloadMax {
+				return sv2ProtocolUnknown, fmt.Errorf("sv2 plaintext setup payload too large: %d", payLen)
+			}
+		}
+		return sv2ProtocolPlaintext, nil
+	}
+	// Encrypted SV2 cannot be positively identified before the Noise handshake on
+	// a shared listener. We keep a bounded fallback for compatibility, but the
+	// long-term direction is explicit port separation.
+	return sv2ProtocolEncrypted, nil
+}
+
+func looksLikeJSONRPCStart(b []byte) bool {
+	trimmed := bytes.TrimLeftFunc(b, func(r rune) bool {
+		return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+	})
+	return len(trimmed) > 0 && trimmed[0] == '{'
+}

--- a/stratum_v2_types.go
+++ b/stratum_v2_types.go
@@ -1,0 +1,662 @@
+package main
+
+const (
+	sv2MsgSetupConnection              byte = 0x00
+	sv2MsgSetupConnectionSuccess       byte = 0x01
+	sv2MsgSetupConnectionError         byte = 0x02
+	sv2MsgOpenStandardMiningChannel    byte = 0x10
+	sv2MsgOpenStdMiningChannelSuccess  byte = 0x11
+	sv2MsgOpenMiningChannelError       byte = 0x12
+	sv2MsgOpenStdMiningChannelError    byte = sv2MsgOpenMiningChannelError
+	sv2MsgOpenExtendedMiningChannel    byte = 0x13
+	sv2MsgOpenExtMiningChannelSuccess  byte = 0x14
+	sv2MsgOpenExtMiningChannelError    byte = sv2MsgOpenMiningChannelError
+	sv2MsgNewMiningJob                 byte = 0x15
+	sv2MsgUpdateChannel                byte = 0x16
+	sv2MsgCloseChannel                 byte = 0x18
+	sv2MsgSetNewPrevHash               byte = 0x20
+	sv2MsgSetTarget                    byte = 0x21
+	sv2MsgNewExtendedMiningJob         byte = 0x1f
+	sv2MsgSubmitSharesStandard         byte = 0x1a
+	sv2MsgSubmitSharesExtended         byte = 0x1b
+	sv2MsgSubmitSharesSuccess          byte = 0x1c
+	sv2MsgSubmitSharesError            byte = 0x1d
+)
+
+// sv2SetupConnection (0x00): miner → pool
+type sv2SetupConnection struct {
+	Protocol        uint8
+	MinVersion      uint16
+	MaxVersion      uint16
+	Flags           uint32
+	EndpointHost    string
+	EndpointPort    uint16
+	Vendor          string
+	HardwareVersion string
+	Firmware        string
+	DeviceID        string
+}
+
+func (m *sv2SetupConnection) decode(b []byte) error {
+	off := 0
+	var err error
+	if m.Protocol, err = sv2ReadU8(b, &off); err != nil {
+		return err
+	}
+	if m.MinVersion, err = sv2ReadU16(b, &off); err != nil {
+		return err
+	}
+	if m.MaxVersion, err = sv2ReadU16(b, &off); err != nil {
+		return err
+	}
+	if m.Flags, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	if m.EndpointHost, err = sv2ReadStr(b, &off); err != nil {
+		return err
+	}
+	if m.EndpointPort, err = sv2ReadU16(b, &off); err != nil {
+		return err
+	}
+	if m.Vendor, err = sv2ReadStr(b, &off); err != nil {
+		return err
+	}
+	if m.HardwareVersion, err = sv2ReadStr(b, &off); err != nil {
+		return err
+	}
+	if m.Firmware, err = sv2ReadStr(b, &off); err != nil {
+		return err
+	}
+	m.DeviceID, err = sv2ReadStr(b, &off)
+	return err
+}
+
+func (m *sv2SetupConnection) encode() []byte {
+	var b []byte
+	b = sv2AppendU8(b, m.Protocol)
+	b = sv2AppendU16(b, m.MinVersion)
+	b = sv2AppendU16(b, m.MaxVersion)
+	b = sv2AppendU32(b, m.Flags)
+	b = sv2AppendStr(b, m.EndpointHost)
+	b = sv2AppendU16(b, m.EndpointPort)
+	b = sv2AppendStr(b, m.Vendor)
+	b = sv2AppendStr(b, m.HardwareVersion)
+	b = sv2AppendStr(b, m.Firmware)
+	b = sv2AppendStr(b, m.DeviceID)
+	return b
+}
+
+// sv2SetupConnectionSuccess (0x01): pool → miner
+type sv2SetupConnectionSuccess struct {
+	UsedVersion uint16
+	Flags       uint32
+}
+
+func (m *sv2SetupConnectionSuccess) encode() []byte {
+	var b []byte
+	b = sv2AppendU16(b, m.UsedVersion)
+	b = sv2AppendU32(b, m.Flags)
+	return b
+}
+
+func (m *sv2SetupConnectionSuccess) decode(b []byte) error {
+	off := 0
+	var err error
+	if m.UsedVersion, err = sv2ReadU16(b, &off); err != nil {
+		return err
+	}
+	m.Flags, err = sv2ReadU32(b, &off)
+	return err
+}
+
+// sv2SetupConnectionError (0x02): pool → miner
+type sv2SetupConnectionError struct {
+	Flags     uint32
+	ErrorCode string
+}
+
+func (m *sv2SetupConnectionError) encode() []byte {
+	var b []byte
+	b = sv2AppendU32(b, m.Flags)
+	b = sv2AppendStr(b, m.ErrorCode)
+	return b
+}
+
+func (m *sv2SetupConnectionError) decode(b []byte) error {
+	off := 0
+	var err error
+	if m.Flags, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	m.ErrorCode, err = sv2ReadStr(b, &off)
+	return err
+}
+
+// sv2OpenStandardMiningChannel (0x10): miner → pool
+type sv2OpenStandardMiningChannel struct {
+	RequestID       uint32
+	UserIdentity    string
+	NominalHashRate float32
+	MaxTarget       [32]byte
+}
+
+func (m *sv2OpenStandardMiningChannel) decode(b []byte) error {
+	off := 0
+	var err error
+	if m.RequestID, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	if m.UserIdentity, err = sv2ReadStr(b, &off); err != nil {
+		return err
+	}
+	if m.NominalHashRate, err = sv2ReadF32(b, &off); err != nil {
+		return err
+	}
+	m.MaxTarget, err = sv2ReadU256(b, &off)
+	return err
+}
+
+func (m *sv2OpenStandardMiningChannel) encode() []byte {
+	var b []byte
+	b = sv2AppendU32(b, m.RequestID)
+	b = sv2AppendStr(b, m.UserIdentity)
+	b = sv2AppendF32(b, m.NominalHashRate)
+	b = sv2AppendU256(b, m.MaxTarget)
+	return b
+}
+
+// sv2OpenStdMiningChannelSuccess (0x11): pool → miner
+type sv2OpenStdMiningChannelSuccess struct {
+	RequestID        uint32
+	ChannelID        uint32
+	Target           [32]byte
+	ExtraNoncePrefix []byte // B0_32: u8 length prefix, 0-32 bytes
+	GroupChannelID   uint32
+}
+
+func (m *sv2OpenStdMiningChannelSuccess) encode() []byte {
+	var b []byte
+	b = sv2AppendU32(b, m.RequestID)
+	b = sv2AppendU32(b, m.ChannelID)
+	b = sv2AppendU256(b, m.Target)
+	b = sv2AppendBytes(b, m.ExtraNoncePrefix) // u8 length prefix
+	b = sv2AppendU32(b, m.GroupChannelID)
+	return b
+}
+
+func (m *sv2OpenStdMiningChannelSuccess) decode(b []byte) error {
+	off := 0
+	var err error
+	if m.RequestID, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	if m.ChannelID, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	if m.Target, err = sv2ReadU256(b, &off); err != nil {
+		return err
+	}
+	if m.ExtraNoncePrefix, err = sv2ReadBytes(b, &off); err != nil {
+		return err
+	}
+	m.GroupChannelID, err = sv2ReadU32(b, &off)
+	return err
+}
+
+// sv2OpenStdMiningChannelError (0x12): pool → miner
+type sv2OpenStdMiningChannelError struct {
+	RequestID uint32
+	ErrorCode string
+}
+
+func (m *sv2OpenStdMiningChannelError) encode() []byte {
+	var b []byte
+	b = sv2AppendU32(b, m.RequestID)
+	b = sv2AppendStr(b, m.ErrorCode)
+	return b
+}
+
+func (m *sv2OpenStdMiningChannelError) decode(b []byte) error {
+	off := 0
+	var err error
+	if m.RequestID, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	m.ErrorCode, err = sv2ReadStr(b, &off)
+	return err
+}
+
+// sv2OpenExtendedMiningChannel (0x13): miner → pool
+type sv2OpenExtendedMiningChannel struct {
+	RequestID         uint32
+	UserIdentity      string
+	NominalHashRate   float32
+	MaxTarget         [32]byte
+	MinExtranonceSize uint16
+}
+
+func (m *sv2OpenExtendedMiningChannel) decode(b []byte) error {
+	off := 0
+	var err error
+	if m.RequestID, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	if m.UserIdentity, err = sv2ReadStr(b, &off); err != nil {
+		return err
+	}
+	if m.NominalHashRate, err = sv2ReadF32(b, &off); err != nil {
+		return err
+	}
+	if m.MaxTarget, err = sv2ReadU256(b, &off); err != nil {
+		return err
+	}
+	m.MinExtranonceSize, err = sv2ReadU16(b, &off)
+	return err
+}
+
+func (m *sv2OpenExtendedMiningChannel) encode() []byte {
+	var b []byte
+	b = sv2AppendU32(b, m.RequestID)
+	b = sv2AppendStr(b, m.UserIdentity)
+	b = sv2AppendF32(b, m.NominalHashRate)
+	b = sv2AppendU256(b, m.MaxTarget)
+	b = sv2AppendU16(b, m.MinExtranonceSize)
+	return b
+}
+
+// sv2OpenExtMiningChannelSuccess (0x14): pool → miner
+type sv2OpenExtMiningChannelSuccess struct {
+	RequestID        uint32
+	ChannelID        uint32
+	Target           [32]byte
+	ExtranonceSize   uint16
+	ExtraNoncePrefix []byte // B0_32: u8 length prefix, 0-32 bytes
+	GroupChannelID   uint32
+}
+
+func (m *sv2OpenExtMiningChannelSuccess) encode() []byte {
+	var b []byte
+	b = sv2AppendU32(b, m.RequestID)
+	b = sv2AppendU32(b, m.ChannelID)
+	b = sv2AppendU256(b, m.Target)
+	b = sv2AppendU16(b, m.ExtranonceSize)
+	b = sv2AppendBytes(b, m.ExtraNoncePrefix) // u8 length prefix
+	b = sv2AppendU32(b, m.GroupChannelID)
+	return b
+}
+
+func (m *sv2OpenExtMiningChannelSuccess) decode(b []byte) error {
+	off := 0
+	var err error
+	if m.RequestID, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	if m.ChannelID, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	if m.Target, err = sv2ReadU256(b, &off); err != nil {
+		return err
+	}
+	if m.ExtranonceSize, err = sv2ReadU16(b, &off); err != nil {
+		return err
+	}
+	if m.ExtraNoncePrefix, err = sv2ReadBytes(b, &off); err != nil {
+		return err
+	}
+	m.GroupChannelID, err = sv2ReadU32(b, &off)
+	return err
+}
+
+// sv2OpenExtMiningChannelError (0x15): pool → miner
+type sv2OpenExtMiningChannelError struct {
+	RequestID uint32
+	ErrorCode string
+}
+
+func (m *sv2OpenExtMiningChannelError) encode() []byte {
+	var b []byte
+	b = sv2AppendU32(b, m.RequestID)
+	b = sv2AppendStr(b, m.ErrorCode)
+	return b
+}
+
+func (m *sv2OpenExtMiningChannelError) decode(b []byte) error {
+	off := 0
+	var err error
+	if m.RequestID, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	m.ErrorCode, err = sv2ReadStr(b, &off)
+	return err
+}
+
+// sv2NewExtendedMiningJob (0x1f): pool → miner
+type sv2NewExtendedMiningJob struct {
+	ChannelID             uint32
+	JobID                 uint32
+	MinNTime              *uint32 // Sv2Option<U32>
+	Version               uint32
+	VersionRollingAllowed bool
+	MerklePath            [][32]byte
+	CbPrefix              []byte // B0_64K: u16 length prefix
+	CbSuffix              []byte // B0_64K: u16 length prefix
+}
+
+func (m *sv2NewExtendedMiningJob) encode() []byte {
+	var b []byte
+	b = sv2AppendU32(b, m.ChannelID)
+	b = sv2AppendU32(b, m.JobID)
+	b = sv2AppendOptU32(b, m.MinNTime)
+	b = sv2AppendU32(b, m.Version)
+	b = sv2AppendBool(b, m.VersionRollingAllowed)
+	b = sv2AppendU256Seq(b, m.MerklePath)
+	b = sv2AppendBytesB0_64K(b, m.CbPrefix)
+	b = sv2AppendBytesB0_64K(b, m.CbSuffix)
+	return b
+}
+
+func (m *sv2NewExtendedMiningJob) decode(b []byte) error {
+	off := 0
+	var err error
+	if m.ChannelID, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	if m.JobID, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	if m.MinNTime, err = sv2ReadOptU32(b, &off); err != nil {
+		return err
+	}
+	if m.Version, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	if m.VersionRollingAllowed, err = sv2ReadBool(b, &off); err != nil {
+		return err
+	}
+	if m.MerklePath, err = sv2ReadU256Seq(b, &off); err != nil {
+		return err
+	}
+	if m.CbPrefix, err = sv2ReadBytesB0_64K(b, &off); err != nil {
+		return err
+	}
+	m.CbSuffix, err = sv2ReadBytesB0_64K(b, &off)
+	return err
+}
+
+// sv2NewMiningJob (0x15): pool -> miner
+// Standard channels only: fixed merkle root, header-only mining.
+type sv2NewMiningJob struct {
+	ChannelID uint32
+	JobID     uint32
+	MinNTime  *uint32 // Sv2Option<U32>
+	Version   uint32
+	MerkleRoot [32]byte
+}
+
+func (m *sv2NewMiningJob) encode() []byte {
+	var b []byte
+	b = sv2AppendU32(b, m.ChannelID)
+	b = sv2AppendU32(b, m.JobID)
+	b = sv2AppendOptU32(b, m.MinNTime)
+	b = sv2AppendU32(b, m.Version)
+	b = sv2AppendU256(b, m.MerkleRoot)
+	return b
+}
+
+func (m *sv2NewMiningJob) decode(b []byte) error {
+	off := 0
+	var err error
+	if m.ChannelID, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	if m.JobID, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	if m.MinNTime, err = sv2ReadOptU32(b, &off); err != nil {
+		return err
+	}
+	if m.Version, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	m.MerkleRoot, err = sv2ReadU256(b, &off)
+	return err
+}
+
+// sv2SetNewPrevHash (0x20): pool → miner
+type sv2SetNewPrevHash struct {
+	ChannelID uint32
+	JobID     uint32
+	PrevHash  [32]byte
+	MinNTime  uint32
+	NBits     uint32
+}
+
+func (m *sv2SetNewPrevHash) encode() []byte {
+	var b []byte
+	b = sv2AppendU32(b, m.ChannelID)
+	b = sv2AppendU32(b, m.JobID)
+	b = sv2AppendU256(b, m.PrevHash)
+	b = sv2AppendU32(b, m.MinNTime)
+	b = sv2AppendU32(b, m.NBits)
+	return b
+}
+
+func (m *sv2SetNewPrevHash) decode(b []byte) error {
+	off := 0
+	var err error
+	if m.ChannelID, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	if m.JobID, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	if m.PrevHash, err = sv2ReadU256(b, &off); err != nil {
+		return err
+	}
+	if m.MinNTime, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	m.NBits, err = sv2ReadU32(b, &off)
+	return err
+}
+
+// sv2SetTarget (0x21): pool → miner
+type sv2SetTarget struct {
+	ChannelID     uint32
+	MaximumTarget [32]byte
+}
+
+func (m *sv2SetTarget) encode() []byte {
+	var b []byte
+	b = sv2AppendU32(b, m.ChannelID)
+	b = sv2AppendU256(b, m.MaximumTarget)
+	return b
+}
+
+func (m *sv2SetTarget) decode(b []byte) error {
+	off := 0
+	var err error
+	if m.ChannelID, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	m.MaximumTarget, err = sv2ReadU256(b, &off)
+	return err
+}
+
+// sv2SubmitSharesStandard (0x1a): miner → pool
+type sv2SubmitSharesStandard struct {
+	ChannelID      uint32
+	SequenceNumber uint32
+	JobID          uint32
+	Nonce          uint32
+	NTime          uint32
+	Version        uint32
+}
+
+// sv2SubmitSharesExtended (0x1b): miner → pool
+type sv2SubmitSharesExtended struct {
+	ChannelID      uint32
+	SequenceNumber uint32
+	JobID          uint32
+	Nonce          uint32
+	NTime          uint32
+	Version        uint32
+	Extranonce     []byte // B0_32: u8 length prefix, 0-32 bytes
+}
+
+func (m *sv2SubmitSharesExtended) decode(b []byte) error {
+	_, err := m.decodeWithTrailing(b)
+	return err
+}
+
+func (m *sv2SubmitSharesExtended) decodeWithTrailing(b []byte) ([]byte, error) {
+	off := 0
+	var err error
+	if m.ChannelID, err = sv2ReadU32(b, &off); err != nil {
+		return nil, err
+	}
+	if m.SequenceNumber, err = sv2ReadU32(b, &off); err != nil {
+		return nil, err
+	}
+	if m.JobID, err = sv2ReadU32(b, &off); err != nil {
+		return nil, err
+	}
+	if m.Nonce, err = sv2ReadU32(b, &off); err != nil {
+		return nil, err
+	}
+	if m.NTime, err = sv2ReadU32(b, &off); err != nil {
+		return nil, err
+	}
+	if m.Version, err = sv2ReadU32(b, &off); err != nil {
+		return nil, err
+	}
+	m.Extranonce, err = sv2ReadBytes(b, &off)
+	if err != nil {
+		return nil, err
+	}
+	if off >= len(b) {
+		return nil, nil
+	}
+	trailing := make([]byte, len(b)-off)
+	copy(trailing, b[off:])
+	return trailing, nil
+}
+
+func (m *sv2SubmitSharesExtended) encode() []byte {
+	var b []byte
+	b = sv2AppendU32(b, m.ChannelID)
+	b = sv2AppendU32(b, m.SequenceNumber)
+	b = sv2AppendU32(b, m.JobID)
+	b = sv2AppendU32(b, m.Nonce)
+	b = sv2AppendU32(b, m.NTime)
+	b = sv2AppendU32(b, m.Version)
+	b = sv2AppendBytes(b, m.Extranonce)
+	return b
+}
+
+func (m *sv2SubmitSharesStandard) decode(b []byte) error {
+	_, err := m.decodeWithTrailing(b)
+	return err
+}
+
+func (m *sv2SubmitSharesStandard) decodeWithTrailing(b []byte) ([]byte, error) {
+	off := 0
+	var err error
+	if m.ChannelID, err = sv2ReadU32(b, &off); err != nil {
+		return nil, err
+	}
+	if m.SequenceNumber, err = sv2ReadU32(b, &off); err != nil {
+		return nil, err
+	}
+	if m.JobID, err = sv2ReadU32(b, &off); err != nil {
+		return nil, err
+	}
+	if m.Nonce, err = sv2ReadU32(b, &off); err != nil {
+		return nil, err
+	}
+	if m.NTime, err = sv2ReadU32(b, &off); err != nil {
+		return nil, err
+	}
+	m.Version, err = sv2ReadU32(b, &off)
+	if err != nil {
+		return nil, err
+	}
+	if off >= len(b) {
+		return nil, nil
+	}
+	trailing := make([]byte, len(b)-off)
+	copy(trailing, b[off:])
+	return trailing, nil
+}
+
+func (m *sv2SubmitSharesStandard) encode() []byte {
+	var b []byte
+	b = sv2AppendU32(b, m.ChannelID)
+	b = sv2AppendU32(b, m.SequenceNumber)
+	b = sv2AppendU32(b, m.JobID)
+	b = sv2AppendU32(b, m.Nonce)
+	b = sv2AppendU32(b, m.NTime)
+	b = sv2AppendU32(b, m.Version)
+	return b
+}
+
+// sv2SubmitSharesSuccess (0x1c): pool → miner
+type sv2SubmitSharesSuccess struct {
+	ChannelID               uint32
+	LastSequenceNumber      uint32
+	NewSubmitsAcceptedCount uint32
+	NewSharesSum            uint64
+}
+
+func (m *sv2SubmitSharesSuccess) encode() []byte {
+	var b []byte
+	b = sv2AppendU32(b, m.ChannelID)
+	b = sv2AppendU32(b, m.LastSequenceNumber)
+	b = sv2AppendU32(b, m.NewSubmitsAcceptedCount)
+	b = sv2AppendU64(b, m.NewSharesSum)
+	return b
+}
+
+func (m *sv2SubmitSharesSuccess) decode(b []byte) error {
+	off := 0
+	var err error
+	if m.ChannelID, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	if m.LastSequenceNumber, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	if m.NewSubmitsAcceptedCount, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	m.NewSharesSum, err = sv2ReadU64(b, &off)
+	return err
+}
+
+// sv2SubmitSharesError (0x1d): pool → miner
+type sv2SubmitSharesError struct {
+	ChannelID      uint32
+	SequenceNumber uint32
+	ErrorCode      string
+}
+
+func (m *sv2SubmitSharesError) encode() []byte {
+	var b []byte
+	b = sv2AppendU32(b, m.ChannelID)
+	b = sv2AppendU32(b, m.SequenceNumber)
+	b = sv2AppendStr(b, m.ErrorCode)
+	return b
+}
+
+func (m *sv2SubmitSharesError) decode(b []byte) error {
+	off := 0
+	var err error
+	if m.ChannelID, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	if m.SequenceNumber, err = sv2ReadU32(b, &off); err != nil {
+		return err
+	}
+	m.ErrorCode, err = sv2ReadStr(b, &off)
+	return err
+}

--- a/stratum_v2_types_roundtrip_test.go
+++ b/stratum_v2_types_roundtrip_test.go
@@ -1,0 +1,280 @@
+package main
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+func filledU256(seed byte) [32]byte {
+	var out [32]byte
+	for i := range out {
+		out[i] = seed + byte(i)
+	}
+	return out
+}
+
+func TestSV2TypesRoundTripCoverage(t *testing.T) {
+	t.Run("SetupConnectionSuccess", func(t *testing.T) {
+		in := sv2SetupConnectionSuccess{UsedVersion: 2, Flags: 0xAABBCCDD}
+		var out sv2SetupConnectionSuccess
+		if err := out.decode(in.encode()); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out != in {
+			t.Fatalf("mismatch: got %+v want %+v", out, in)
+		}
+	})
+
+	t.Run("SetupConnectionError", func(t *testing.T) {
+		in := sv2SetupConnectionError{Flags: 7, ErrorCode: "unsupported-protocol"}
+		var out sv2SetupConnectionError
+		if err := out.decode(in.encode()); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out != in {
+			t.Fatalf("mismatch: got %+v want %+v", out, in)
+		}
+	})
+
+	t.Run("OpenStandardMiningChannel", func(t *testing.T) {
+		in := sv2OpenStandardMiningChannel{
+			RequestID:       99,
+			UserIdentity:    "worker.001",
+			NominalHashRate: 1234.5,
+			MaxTarget:       filledU256(0x10),
+		}
+		var out sv2OpenStandardMiningChannel
+		if err := out.decode(in.encode()); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out.RequestID != in.RequestID || out.UserIdentity != in.UserIdentity || out.MaxTarget != in.MaxTarget {
+			t.Fatalf("field mismatch: got %+v want %+v", out, in)
+		}
+		if math.Abs(float64(out.NominalHashRate-in.NominalHashRate)) > 1e-4 {
+			t.Fatalf("hashrate mismatch: got %f want %f", out.NominalHashRate, in.NominalHashRate)
+		}
+	})
+
+	t.Run("OpenStdMiningChannelSuccess", func(t *testing.T) {
+		in := sv2OpenStdMiningChannelSuccess{
+			RequestID:        1,
+			ChannelID:        2,
+			Target:           filledU256(0x11),
+			ExtraNoncePrefix: []byte{0x01, 0x02, 0x03},
+			GroupChannelID:   3,
+		}
+		var out sv2OpenStdMiningChannelSuccess
+		if err := out.decode(in.encode()); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out.RequestID != in.RequestID || out.ChannelID != in.ChannelID || out.Target != in.Target || out.GroupChannelID != in.GroupChannelID {
+			t.Fatalf("field mismatch: got %+v want %+v", out, in)
+		}
+		if !bytes.Equal(out.ExtraNoncePrefix, in.ExtraNoncePrefix) {
+			t.Fatalf("extranonce prefix mismatch: got %x want %x", out.ExtraNoncePrefix, in.ExtraNoncePrefix)
+		}
+	})
+
+	t.Run("OpenStdMiningChannelError", func(t *testing.T) {
+		in := sv2OpenStdMiningChannelError{RequestID: 7, ErrorCode: "not-authorized"}
+		var out sv2OpenStdMiningChannelError
+		if err := out.decode(in.encode()); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out != in {
+			t.Fatalf("mismatch: got %+v want %+v", out, in)
+		}
+	})
+
+	t.Run("OpenExtendedMiningChannel", func(t *testing.T) {
+		in := sv2OpenExtendedMiningChannel{
+			RequestID:         13,
+			UserIdentity:      "wallet.worker",
+			NominalHashRate:   9876.25,
+			MaxTarget:         filledU256(0x22),
+			MinExtranonceSize: 6,
+		}
+		var out sv2OpenExtendedMiningChannel
+		if err := out.decode(in.encode()); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out.RequestID != in.RequestID || out.UserIdentity != in.UserIdentity || out.MaxTarget != in.MaxTarget || out.MinExtranonceSize != in.MinExtranonceSize {
+			t.Fatalf("field mismatch: got %+v want %+v", out, in)
+		}
+		if math.Abs(float64(out.NominalHashRate-in.NominalHashRate)) > 1e-4 {
+			t.Fatalf("hashrate mismatch: got %f want %f", out.NominalHashRate, in.NominalHashRate)
+		}
+	})
+
+	t.Run("OpenExtMiningChannelSuccess", func(t *testing.T) {
+		in := sv2OpenExtMiningChannelSuccess{
+			RequestID:        5,
+			ChannelID:        6,
+			Target:           filledU256(0x33),
+			ExtranonceSize:   8,
+			ExtraNoncePrefix: []byte{0xaa, 0xbb},
+			GroupChannelID:   9,
+		}
+		var out sv2OpenExtMiningChannelSuccess
+		if err := out.decode(in.encode()); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out.RequestID != in.RequestID || out.ChannelID != in.ChannelID || out.Target != in.Target || out.ExtranonceSize != in.ExtranonceSize || out.GroupChannelID != in.GroupChannelID {
+			t.Fatalf("field mismatch: got %+v want %+v", out, in)
+		}
+		if !bytes.Equal(out.ExtraNoncePrefix, in.ExtraNoncePrefix) {
+			t.Fatalf("extranonce prefix mismatch: got %x want %x", out.ExtraNoncePrefix, in.ExtraNoncePrefix)
+		}
+	})
+
+	t.Run("OpenExtMiningChannelError", func(t *testing.T) {
+		in := sv2OpenExtMiningChannelError{RequestID: 77, ErrorCode: "invalid-min-extranonce-size"}
+		var out sv2OpenExtMiningChannelError
+		if err := out.decode(in.encode()); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out != in {
+			t.Fatalf("mismatch: got %+v want %+v", out, in)
+		}
+	})
+
+	t.Run("NewExtendedMiningJobWithMinNTime", func(t *testing.T) {
+		minNTime := uint32(1700000000)
+		in := sv2NewExtendedMiningJob{
+			ChannelID:             1,
+			JobID:                 2,
+			MinNTime:              &minNTime,
+			Version:               0x20000000,
+			VersionRollingAllowed: true,
+			MerklePath:            [][32]byte{filledU256(0x44), filledU256(0x55)},
+			CbPrefix:              []byte{0xde, 0xad},
+			CbSuffix:              []byte{0xbe, 0xef, 0x01},
+		}
+		var out sv2NewExtendedMiningJob
+		if err := out.decode(in.encode()); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out.ChannelID != in.ChannelID || out.JobID != in.JobID || out.Version != in.Version || out.VersionRollingAllowed != in.VersionRollingAllowed {
+			t.Fatalf("field mismatch: got %+v want %+v", out, in)
+		}
+		if out.MinNTime == nil || *out.MinNTime != *in.MinNTime {
+			t.Fatalf("min_ntime mismatch: got %v want %v", out.MinNTime, in.MinNTime)
+		}
+		if len(out.MerklePath) != len(in.MerklePath) || out.MerklePath[0] != in.MerklePath[0] || out.MerklePath[1] != in.MerklePath[1] {
+			t.Fatalf("merkle path mismatch")
+		}
+		if !bytes.Equal(out.CbPrefix, in.CbPrefix) || !bytes.Equal(out.CbSuffix, in.CbSuffix) {
+			t.Fatalf("coinbase parts mismatch")
+		}
+	})
+
+	t.Run("NewExtendedMiningJobWithoutMinNTime", func(t *testing.T) {
+		in := sv2NewExtendedMiningJob{ChannelID: 7, JobID: 8, Version: 9, VersionRollingAllowed: false}
+		var out sv2NewExtendedMiningJob
+		if err := out.decode(in.encode()); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out.MinNTime != nil {
+			t.Fatalf("expected nil min_ntime, got %v", *out.MinNTime)
+		}
+	})
+
+	t.Run("NewMiningJob", func(t *testing.T) {
+		minNTime := uint32(1717171717)
+		in := sv2NewMiningJob{
+			ChannelID:  12,
+			JobID:      34,
+			MinNTime:   &minNTime,
+			Version:    0x20000000,
+			MerkleRoot: filledU256(0x5a),
+		}
+		var out sv2NewMiningJob
+		if err := out.decode(in.encode()); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out.ChannelID != in.ChannelID || out.JobID != in.JobID || out.Version != in.Version || out.MerkleRoot != in.MerkleRoot {
+			t.Fatalf("field mismatch: got %+v want %+v", out, in)
+		}
+		if out.MinNTime == nil || *out.MinNTime != *in.MinNTime {
+			t.Fatalf("min_ntime mismatch: got %v want %v", out.MinNTime, in.MinNTime)
+		}
+	})
+
+	t.Run("SetNewPrevHash", func(t *testing.T) {
+		in := sv2SetNewPrevHash{
+			ChannelID: 9,
+			JobID:     10,
+			PrevHash:  filledU256(0x66),
+			MinNTime:  1717171717,
+			NBits:     0x17020f79,
+		}
+		var out sv2SetNewPrevHash
+		if err := out.decode(in.encode()); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out != in {
+			t.Fatalf("mismatch: got %+v want %+v", out, in)
+		}
+	})
+
+	t.Run("SetTarget", func(t *testing.T) {
+		in := sv2SetTarget{ChannelID: 11, MaximumTarget: filledU256(0x77)}
+		var out sv2SetTarget
+		if err := out.decode(in.encode()); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out != in {
+			t.Fatalf("mismatch: got %+v want %+v", out, in)
+		}
+	})
+
+	t.Run("SubmitSharesExtended", func(t *testing.T) {
+		in := sv2SubmitSharesExtended{
+			ChannelID:      1,
+			SequenceNumber: 2,
+			JobID:          3,
+			Nonce:          4,
+			NTime:          5,
+			Version:        6,
+			Extranonce:     []byte{0x01, 0x02},
+		}
+		var out sv2SubmitSharesExtended
+		if err := out.decode(in.encode()); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out.ChannelID != in.ChannelID || out.SequenceNumber != in.SequenceNumber || out.JobID != in.JobID || out.Nonce != in.Nonce || out.NTime != in.NTime || out.Version != in.Version {
+			t.Fatalf("field mismatch: got %+v want %+v", out, in)
+		}
+		if !bytes.Equal(out.Extranonce, in.Extranonce) {
+			t.Fatalf("extranonce mismatch: got %x want %x", out.Extranonce, in.Extranonce)
+		}
+	})
+
+	t.Run("SubmitSharesSuccess", func(t *testing.T) {
+		in := sv2SubmitSharesSuccess{
+			ChannelID:               12,
+			LastSequenceNumber:      34,
+			NewSubmitsAcceptedCount: 56,
+			NewSharesSum:            78,
+		}
+		var out sv2SubmitSharesSuccess
+		if err := out.decode(in.encode()); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out != in {
+			t.Fatalf("mismatch: got %+v want %+v", out, in)
+		}
+	})
+
+	t.Run("SubmitSharesError", func(t *testing.T) {
+		in := sv2SubmitSharesError{ChannelID: 90, SequenceNumber: 91, ErrorCode: "stale-share"}
+		var out sv2SubmitSharesError
+		if err := out.decode(in.encode()); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out != in {
+			t.Fatalf("mismatch: got %+v want %+v", out, in)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Introduce the core Stratum V2 protocol building blocks that later runtime and validation work build on.

This PR is intentionally limited to protocol primitives. It adds the low-level SV2 foundation without introducing listener wiring or changing share-processing behavior.

## What’s Included

- SV2 frame encoding and decoding
- protocol message definitions and shared types
- NOISE transport and key handling
- primitive-focused round-trip and protocol tests

## What’s Not Included

- runtime listener integration
- pool startup wiring
- SV2 submit handling or validation
- block reconstruction or submitblock flow

## Why This Split

Keeping the protocol foundation separate makes the later PRs easier to review:
- PR1 establishes the message and transport layer
- PR2 wires SV2 into the running pool
- PR3 enables submit validation and reconstruction

## Testing

- `go test ./...`

## Stack Context

This is PR1 of 3.